### PR TITLE
Update hautelook/templated-uri-router to 4.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     "require": {
         "php": "^5.4|^7.0|^8.0",
         "symfony/framework-bundle": "^2.8|^3.0|^4.0|^5.0|^6.0",
-        "hautelook/templated-uri-router": "^2.0|^3.0"
+        "hautelook/templated-uri-router": "^2.0|^3.0|^4.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^4.8.36|^5.0|^6.0|^7.0"


### PR DESCRIPTION
`hautelook/templated-uri-router` v4.0 fixes a bug that made previous version incompatible with Symfony 6. This PR simply allows the bundle to use the latest version of that package.